### PR TITLE
Make `topVC` a computed var

### DIFF
--- a/GPhotos/Helpers/Const.swift
+++ b/GPhotos/Helpers/Const.swift
@@ -11,7 +11,7 @@ import GTMAppAuth
 
 //MARK: Global variables
 
-internal var topVC: UIViewController? = {
+internal var topVC: UIViewController? {
     if var topController = UIApplication.shared.keyWindow?.rootViewController {
         while let presentedViewController = topController.presentedViewController {
             topController = presentedViewController
@@ -19,7 +19,7 @@ internal var topVC: UIViewController? = {
         return topController
     }
     return nil
-}()
+}
 
 internal var config = Config()
 internal var defaults = UserDefaults.standard


### PR DESCRIPTION
Sometimes the `rootViewController` can change during an app lifecycle; for example replacing a "loading" screen by the main screen of the app.
Depending when `GPhotos.validate` is called the first time, we might keep a reference to view controller removed from the hierarchy.
Using a computed var instead of a lazy var is a bit more cpu intensive but `topVC` does not seems to be called a lot and this can prevent errors like : 
```
com.apple.AuthenticationServices.WebAuthenticationSession Code=2 "Cannot start ASWebAuthenticationSession without providing presentation context. Set presentationContextProvider before calling -start." 
```