### PR TITLE
Feature/update dependencies

### DIFF
--- a/Example/GPhotos.xcodeproj/project.pbxproj
+++ b/Example/GPhotos.xcodeproj/project.pbxproj
@@ -280,7 +280,6 @@
 				"${BUILT_PRODUCTS_DIR}/GTMSessionFetcher/GTMSessionFetcher.framework",
 				"${BUILT_PRODUCTS_DIR}/Moya/Moya.framework",
 				"${BUILT_PRODUCTS_DIR}/ObjectMapper/ObjectMapper.framework",
-				"${BUILT_PRODUCTS_DIR}/Result/Result.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -291,7 +290,6 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMSessionFetcher.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Moya.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ObjectMapper.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Result.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -440,7 +438,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -489,7 +487,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -503,7 +501,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = GPhotos/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.deivitaka.GPhotos-Example";
@@ -519,7 +516,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = GPhotos/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.deivitaka.GPhotos-Example";

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '8.0'
+platform :ios, '10.0'
 use_frameworks!
 
 target 'GPhotos_Example' do

--- a/GPhotos.podspec
+++ b/GPhotos.podspec
@@ -18,11 +18,11 @@ Pod::Spec.new do |s|
     s.source_files  = "GPhotos/**/*"
     # s.exclude_files = "GPhotosTests/*.swift"
     s.swift_version = "5.0"
-    s.platform     = :ios, "8.0"
+    s.platform     = :ios, "10.0"
     
-    s.dependency 'GTMAppAuth', '~> 1.0.0'
-    s.dependency 'AppAuth', '~> 1.0'
-    s.dependency 'Moya', '~> 13.0'
-    s.dependency 'ObjectMapper', '~> 3.4'
+    s.dependency 'GTMAppAuth', '~> 1.1.0'
+    s.dependency 'AppAuth', '~> 1.4'
+    s.dependency 'Moya', '~> 14.0'
+    s.dependency 'ObjectMapper', '~> 4.2'
 
 end

--- a/GPhotos/Network/GPhotosApi.swift
+++ b/GPhotos/Network/GPhotosApi.swift
@@ -12,8 +12,8 @@ public struct GPhotosApi {
     private init() {}
     
     internal static let plugins: [PluginType] = [
-        NetworkLoggerPlugin(verbose: config.printNetworkLogs),
-        AccessTokenPlugin(tokenClosure: { return Strings.photosAccessToken })
+        NetworkLoggerPlugin(),
+        AccessTokenPlugin(tokenClosure: { _ in return Strings.photosAccessToken })
     ]
     
     public static let mediaItems = MediaItems()

--- a/GPhotos/Network/Services/GPhotosService.swift
+++ b/GPhotos/Network/Services/GPhotosService.swift
@@ -12,7 +12,7 @@ import ObjectMapper
 protocol GPhotosService : AccessTokenAuthorizable, TargetType {}
 
 extension GPhotosService {
-    var authorizationType: AuthorizationType { return .bearer }
+    var authorizationType: AuthorizationType? { return .bearer }
     var baseURL: URL { return URL(string: "https://photoslibrary.googleapis.com/v1")! }
     var sampleData: Data { return Data() }
     var headers: [String: String]? { return [


### PR DESCRIPTION
Hello !

I would like to upgrade to Alamofire 5 in a project using GPhotos, and the dependency from GPhoto is blocking :

``` 
[!] CocoaPods could not find compatible versions for pod "Alamofire":
  In Podfile:
    Alamofire (~> 5.0.0)

    GPhotos (from `https://github.com/deivitaka/GPhotos`, commit `1b25f7765c196a2ff1966b97e5076a96d49097cb`, branch `master`) was resolved to 0.6.0, which depends on
      Moya (~> 13.0) was resolved to 13.0.1, which depends on
        Moya/Core (= 13.0.1) was resolved to 13.0.1, which depends on
          Alamofire (~> 4.1)
 ```
 
 So I updated all dependencies of GPhotos to the latest stable available.
 > Alamofire 5.4.1 (was 4.9.1)
 > Moya 14.0.0 (was 13.0.1)
 > GTMAppAuth 1.1.0 (was 1.0.0)
 > ObjectMapper 4.2.0 (was 3.5.3)
 
 Also, as Alamofire 5 requires iOS 10, I increased the deployment target to 10.0
 
 